### PR TITLE
🔧 [Chore] #5 - Docker 베이스 이미지를 eclipse-temurin:17-slim으로 업데이트

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN chmod +x ./gradlew
 RUN ./gradlew bootJar -x test
 
 # --- 2. 실행 단계 ---
-# 훨씬 가벼운 JRE 이미지를 최종 실행 환경으로 사용합니다.
-FROM openjdk:17-jre-slim
+# JRE만 포함된 더 작은 이미지 사용
+FROM eclipse-temurin:17-jre
 WORKDIR /app
 
 # 빌드 단계('builder')에서 생성된 JAR 파일을 최종 이미지로 복사합니다.


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->
Docker 베이스 이미지를 `openjdk:17-jre-slim`에서 `eclipse-temurin:17-slim`으로 변경
openjdk:17-jre-slim은 지원하지않고 openjdk:17-slim이 있긴하지만 
OpenJDK 공식 이미지가 2022년부터 deprecated 되어 보안 업데이트 중단 위험이 있고 Eclipse Temurin은 지속적인 보안 업데이트와 공식 지원 제공하고 있어 변경하였습니다. 

+ 더 작은 이미지 크기로 빌드 시간 단축 기대

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- #5 
